### PR TITLE
Replace pull_request_target with pull_request in GitHub Actions workflows

### DIFF
--- a/.github/workflows/insecure.yaml
+++ b/.github/workflows/insecure.yaml
@@ -1,17 +1,13 @@
 # INSECURE. Provided as an example only.
 on:
-  pull_request_target:
-    branches:
-      - main
   push:
     branches:
       - main
-
 jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
This is a Minder automated pull request.

This pull request replaces the 'pull_request_target' event with the 'pull_request' event in GitHub Actions workflows.

The 'pull_request_target' event allows GitHub Actions workflows to run
on pull requests from forks. This can be a security risk, as the event
may, if used improperly, allow untrusted code to run in the
repository.

For more information, see
https://securitylab.github.com/resources/github-actions-preventing-pwn-requests
