### PR TITLE
Replace pull_request_target with pull_request in GitHub Actions workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,12 +14,8 @@
 #
 name: "CodeQL"
 on:
-  pull_request_target:
-    branches: ["main"]
   schedule:
     - cron: '22 15 * * 1'
-  pull_request_target:
-    branches: ["main"]
 jobs:
   analyze:
     name: Analyze
@@ -59,15 +55,15 @@ jobs:
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Build
         run: make build
-      #   If the Autobuild fails above, remove it and uncomment the following three lines.
-      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
       # - run: |
       #     echo "Run, Build Application using script"
       #     ./location_of_script_within_repo/buildscript.sh
       - name: Perform CodeQL Analysis
         # ℹ️ Command-line programs to run using the OS shell.
         # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+        #   If the Autobuild fails above, remove it and uncomment the following three lines.
+        #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
         uses: github/codeql-action/analyze@662472033e021d55d94146f66f6058822b0b39fd # v3
         with:

--- a/.github/workflows/insecure.yaml
+++ b/.github/workflows/insecure.yaml
@@ -1,17 +1,13 @@
 # INSECURE. Provided as an example only.
 on:
-  pull_request_target:
-    branches:
-      - main
   push:
     branches:
       - main
-
 jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
This is a Minder automated pull request.

This pull request replaces the 'pull_request_target' event with the 'pull_request' event in GitHub Actions workflows.

The 'pull_request_target' event allows GitHub Actions workflows to run
on pull requests from forks. This can be a security risk, as the event
may, if used improperly, allow untrusted code to run in the
repository.

For more information, see
https://securitylab.github.com/resources/github-actions-preventing-pwn-requests
